### PR TITLE
Extend opts.strings=true to leftover arguments

### DIFF
--- a/index.js
+++ b/index.js
@@ -187,7 +187,7 @@ module.exports = function (args, opts) {
         else {
             if (!flags.unknownFn || flags.unknownFn(arg) !== false) {
                 argv._.push(
-                    flags.strings['_'] || !isNumber(arg) ? arg : Number(arg)
+                    flags.allStrings || flags.strings['_'] || !isNumber(arg) ? arg : Number(arg)
                 );
             }
             if (opts.stopEarly) {


### PR DESCRIPTION
I just saw the PR of your fork at substack/minimist#109, and because I needed exactly that feature I tried testing it. However, the leftover arguments were still converted to numbers, a.k.a. the ones in `opts._`.

This PR fixes that. And (hopefully) can be merged in the main repository at some point.